### PR TITLE
 Simplified Installation: one line installation 

### DIFF
--- a/lib/oauth2-me.rb
+++ b/lib/oauth2-me.rb
@@ -1,5 +1,6 @@
 require 'base64'
 require 'oauth2-me/omniauth_strategy_updater'
+require 'oauth2-me/railtie' if defined?(Rails)
 
 module OAuth2Me
   class BannedEnvironmentError < StandardError; end

--- a/lib/oauth2-me/railtie.rb
+++ b/lib/oauth2-me/railtie.rb
@@ -1,0 +1,9 @@
+module OAuth2Me
+  class Railtie < Rails::Railtie
+    initializer "oauthtome" do
+      if defined?(Devise)
+        OAuth2Me.setup_devise! unless Rails.env.production?
+      end
+    end
+  end
+end


### PR DESCRIPTION
We should ask users minimum changes in the code. As for me for rails app will fine to have:

```
gem 'oauth2me'
```

will use default scopes and for each omniauth provider setup default api keys.
